### PR TITLE
Rename test file and fix test.

### DIFF
--- a/test/tic_tac_toe_test.exs
+++ b/test/tic_tac_toe_test.exs
@@ -22,7 +22,7 @@ defmodule TicTacToeTest do
     |> TicTacToe.make_move("X", {1, 1})
 
     board_after = game |> TicTacToe.get_board
-    assert board_after[1][1] === "x"
+    assert board_after[1][1] === "X"
   end
 
 


### PR DESCRIPTION
Two small changes:
1) rename `tic_tac_toe.exs` to `tic_tac_toe_test.exs` so that we can run it with `mix test --only exercise14`;
2) capitalize the "X" in test #3 to match the "X" inserted with `make_move` to make test pass.

@mike-north, kindly review :-).